### PR TITLE
feat: implement translation upload functionality for OpenPecha

### DIFF
--- a/backend/apis/openpecha_api.js
+++ b/backend/apis/openpecha_api.js
@@ -1,9 +1,5 @@
 const API_ENDPOINT = process.env.OPENPECHA_ENDPOINT;
 
-/**
- * Step 1: Fetch list of root expressions (title + id)
- * GET /texts?type=root
- */
 async function getTexts(type) {
 	let url = `${API_ENDPOINT}/texts`;
 	if (type) {
@@ -24,10 +20,6 @@ async function getTexts(type) {
 	return data;
 }
 
-/**
- * Step 3: Get list of available instances for a text
- * GET /texts/{text_id}/instances
- */
 async function getTextInstances(text_id) {
 	const response = await fetch(`${API_ENDPOINT}/texts/${text_id}/instances`, {
 		headers: {
@@ -44,10 +36,6 @@ async function getTextInstances(text_id) {
 	return data;
 }
 
-/**
- * Step 4: Fetch serialized text for translation
- * GET /instances/{instance_id}
- */
 async function getInstanceContent(instanceId) {
 	const response = await fetch(`${API_ENDPOINT}/instances/${instanceId}?annotation=true`, {
 		headers: {
@@ -79,10 +67,29 @@ async function getAnnotations(annotation_id){
 	const data = await response.json();
 	return data;
 }
+
+const uploadTranslationToOpenpecha = async (instanceId, translationData) => {
+	const response = await fetch(`${API_ENDPOINT}/instances/${instanceId}/translation`, {
+		method: "POST",
+		headers: {
+			accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(translationData),
+	});
+
+	if (!response.ok) {
+		throw new Error(`Failed to upload translation to openpecha: ${response.statusText}`);
+	}
+
+	const data = await response.json();
+	return data;
+};
+
 module.exports = {
-	// New API flow functions
 	getTexts,
 	getTextInstances,
 	getInstanceContent,
 	getAnnotations,
+	uploadTranslationToOpenpecha,
 };

--- a/backend/services/document.js
+++ b/backend/services/document.js
@@ -1,0 +1,40 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+/**
+ * Fetches a document's details including its content from the current version.
+ * @param {string} documentId - The ID of the document to fetch.
+ * @returns {Promise<object|null>} - An object containing the document's language, name, and content, or null if not found.
+ */
+async function getDocumentWithContent(documentId) {
+  const document = await prisma.doc.findUnique({
+    where: { id: documentId },
+    select: {
+      name: true,
+      language: true,
+      currentVersion: {
+        select: {
+          content: true,
+        },
+      },
+    },
+  });
+
+  if (!document) {
+    return null;
+  }
+
+  const content = document.currentVersion
+    ? document.currentVersion.content
+    : null;
+
+  return {
+    name: document.name,
+    language: document.language,
+    content: content,
+  };
+}
+
+module.exports = {
+  getDocumentWithContent,
+};

--- a/frontend/src/api/openpecha.ts
+++ b/frontend/src/api/openpecha.ts
@@ -44,3 +44,33 @@ export const fetchAnnotations = async (annotationId: string) => {
     return data;
   }
 };
+
+export interface TranslationPayload {
+  language: string;
+  content: string;
+  title: string;
+  segmentation: any;
+  target_annotation: any;
+  alignment_annotation: any;
+}
+
+export const uploadTranslationToOpenpecha = async (
+  instance_id: string,
+  payload: TranslationPayload,
+  translation_doc_id: string,
+) => {
+  const response = await fetch(
+    `${server_url}/openpecha/instances/${instance_id}/translation/${translation_doc_id}`,
+    {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify(payload),
+    },
+  );
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to upload translation");
+  }
+  return response.json();
+};
+

--- a/frontend/src/components/OpenPecha/UploadToOpenPecha.tsx
+++ b/frontend/src/components/OpenPecha/UploadToOpenPecha.tsx
@@ -1,0 +1,107 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useState } from "react";
+import { CheckCircle, Upload } from "lucide-react";
+
+interface UploadToOpenPechaProps {
+  onUpload: () => Promise<boolean>;
+  isUploading: boolean;
+  error: string | null;
+  isUploadable: boolean;
+  translationTitle: string;
+  translationLanguage: string;
+}
+
+export function UploadToOpenPecha({
+  onUpload,
+  isUploading,
+  error,
+  isUploadable,
+  translationTitle,
+  translationLanguage,
+}: UploadToOpenPechaProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleConfirmUpload = async () => {
+    const success = await onUpload();
+    if (success) {
+      setIsSuccess(true);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (isUploading) {
+      return;
+    }
+    setIsOpen(open);
+    if (!open) {
+      setIsSuccess(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button 
+          title={isUploadable ? `Upload to OpenPecha` : "Source document is not uploaded to OpenPecha"}
+          disabled={!isUploadable}
+        >
+          <Upload className="w-4 h-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        {isSuccess ? (
+          <div className="flex flex-col items-center justify-center p-6">
+            <CheckCircle className="w-16 h-16 text-green-500 mb-4" />
+            <DialogTitle>Upload Successful</DialogTitle>
+            <DialogDescription>
+              Your translation has been uploaded successfully.
+            </DialogDescription>
+            <DialogFooter className="mt-6">
+              <Button onClick={() => setIsOpen(false)}>Close</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Confirm Upload</DialogTitle>
+              <DialogDescription>
+                You are about to upload this translation to OpenPecha.
+              </DialogDescription>
+            </DialogHeader>
+            <div>
+              <p>
+                <strong>Title:</strong> {translationTitle}
+              </p>
+              <p>
+                <strong>Language:</strong> {translationLanguage}
+              </p>
+            </div>
+            {error && <p className="text-red-500">{error}</p>}
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                onClick={() => setIsOpen(false)}
+                disabled={isUploading}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmUpload} disabled={isUploading}>
+                {isUploading ? "Uploading..." : "Confirm"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useCurrentDoc.ts
+++ b/frontend/src/hooks/useCurrentDoc.ts
@@ -25,6 +25,13 @@ export interface Document {
   id: string;
   name: string;
   identifier: string;
+  language?: string;
+  metadata?: {
+    [key: string]: unknown;
+    instance_id?: string;
+    text_id?: string;
+    docId?: string;
+  };
   created_at?: string;
   updated_at?: string;
   translations?: Translation[];

--- a/frontend/src/hooks/useOpenPecha.ts
+++ b/frontend/src/hooks/useOpenPecha.ts
@@ -134,7 +134,6 @@ export function useOpenPecha() {
     setProcessedText("");
   }, [selectedTextId]);
 
-  // First useEffect: Trigger fetching of annotations when textContent is available.
 useEffect(() => {
   if (textContent?.annotations?.length) {
     const segmentation = textContent.annotations.find(
@@ -149,7 +148,6 @@ useEffect(() => {
   }
 }, [textContent]);
 
-// Second useEffect: Apply segmentation when both textContent and annotations are ready.
 useEffect(() => {
   if (textContent && annotations) {
     // Note: You might need to adjust `annotations.annotation` based on the actual API response.

--- a/frontend/src/hooks/useOpenPechaUpload.ts
+++ b/frontend/src/hooks/useOpenPechaUpload.ts
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { uploadTranslationToOpenpecha } from "@/api/openpecha";
+import { useEditor } from "@/contexts/EditorContext";
+import { calculateAnnotations } from "@/utils/calculateAnnotations";
+import type { Document } from "./useCurrentDoc";
+
+interface UseOpenPechaUploadProps {
+  sourceDoc: Document | null;
+  translationDoc: Document | null;
+}
+interface Metadata {
+  docId?: string;
+  instance_id?: string;
+  text_id?: string;
+}
+const isMetadataAvailable = (metadata: Metadata | undefined) => {
+  return metadata?.instance_id && metadata?.text_id && metadata?.docId;
+}
+export function useOpenPechaUpload({
+  sourceDoc,
+  translationDoc,
+}: UseOpenPechaUploadProps) {
+  const { getQuill } = useEditor();
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const instance_id = sourceDoc?.metadata?.instance_id as string | undefined;
+  const isUploadable =(() => {
+    if (isMetadataAvailable(sourceDoc?.metadata) && !isMetadataAvailable(translationDoc?.metadata)) {
+      return true;
+    }
+    return false;
+  })();
+  const onUpload = async () => {
+    if (!sourceDoc || !translationDoc || !instance_id) {
+      const missingDataError =
+        "Missing required data: " +
+        (!sourceDoc ? "source document, " : "") +
+        (!translationDoc ? "translation document, " : "") +
+        (!instance_id ? "instance ID" : "");
+      setError(missingDataError);
+      return false;
+    }
+
+    const sourceQuill = getQuill(sourceDoc.id);
+    const translationQuill = getQuill(translationDoc.id);
+
+    if (!sourceQuill || !translationQuill) {
+      setError("Editors not ready or missing data.");
+      return false;
+    }
+
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      const sourceContent = sourceQuill.getText();
+      const sourceContentProcessed = sourceContent.replace(/\n+/g, "\n");
+      const translationContentRaw = translationQuill.getText();
+      const translationContentProcessed = translationContentRaw.replace(
+        /\n+/g,
+        "\n",
+      );
+
+      const { annotations: sourceAnnotations } = calculateAnnotations(
+        sourceContentProcessed,
+      );
+      const {
+        annotations: translationAnnotations,
+        cleanedContent: translationCleanedContent,
+      } = calculateAnnotations(translationContentProcessed);
+
+      const target_annotation = sourceAnnotations.map((anno, index) => ({
+        ...anno,
+        index,
+      }));
+      const segmentation = translationAnnotations;
+      const alignment_annotation = translationAnnotations.map(
+        (anno, index) => ({
+          ...anno,
+          index,
+          alignment_index: [index],
+        }),
+      );
+
+      const payload = {
+        language: translationDoc.language || "en",
+        content: translationCleanedContent,
+        title: translationDoc.name,
+        segmentation,
+        target_annotation,
+        alignment_annotation,
+      };
+
+      await uploadTranslationToOpenpecha(instance_id, payload,translationDoc.id);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unknown error occurred.");
+      return false;
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return {
+    onUpload,
+    isUploading,
+    error,
+    instance_id,
+    isUploadable,
+  };
+}

--- a/frontend/src/utils/calculateAnnotations.ts
+++ b/frontend/src/utils/calculateAnnotations.ts
@@ -1,0 +1,45 @@
+export function calculateAnnotations(content: string): {
+  annotations: Array<{ span: { start: number; end: number } }>;
+  cleanedContent: string;
+} {
+  // Handle empty content
+  if (!content) {
+    return { annotations: [], cleanedContent: "" };
+  }
+  const lines = content.trimEnd().split("\n");
+  const annotations: Array<{ span: { start: number; end: number } }> = [];
+  let cleanedContent = "";
+  let currentPosition = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineLength = line.length;
+
+    if (lineLength === 0) {
+      // Empty line: zero-length span at current position
+      annotations.push({
+        span: {
+          start: currentPosition,
+          end: currentPosition,
+        },
+      });
+      // Position doesn't advance for empty lines
+    } else {
+      // Non-empty line: span covers the text in cleaned content
+      annotations.push({
+        span: {
+          start: currentPosition,
+          end: currentPosition + lineLength,
+        },
+      });
+
+      // Add line text to cleaned content (no newline)
+      cleanedContent += line;
+
+      // Advance position by line length
+      currentPosition += lineLength;
+    }
+  }
+
+  return { annotations, cleanedContent };
+}


### PR DESCRIPTION
- Added `uploadTranslationToOpenpecha` function in the backend API to handle translation uploads.
- Created a new POST route for uploading translations, including validation for required fields.
- Updated frontend API to support translation upload with a new `uploadTranslationToOpenpecha` function.
- Enhanced the DocumentWrapper component to include translation upload capabilities.
- Modified the useCurrentDoc hook to include language and metadata for documents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements an end-to-end translation upload to OpenPecha, adding a backend POST endpoint with validation and Prisma persistence, plus frontend API, UI, and hooks to build and submit annotated payloads.
> 
> - **Backend**:
>   - **API**: Add `uploadTranslationToOpenpecha` in `backend/apis/openpecha_api.js` and new route `POST /openpecha/instances/:instance_id/translation/:translation_doc_id` in `backend/routes/openpecha.js` with required-field validation and author injection via `PERSON_ID`.
>   - **Persistence**: Store uploaded translation linkage in `docMetadata` (`docId`, `instance_id`, `text_id`) via Prisma.
>   - **Service**: Add `backend/services/document.js` with `getDocumentWithContent` helper.
> - **Frontend**:
>   - **API**: Add `uploadTranslationToOpenpecha` with `TranslationPayload` in `frontend/src/api/openpecha.ts`.
>   - **UI/Editor**: Integrate upload control in `DocumentWrapper` translation pane using new component `OpenPecha/UploadToOpenPecha` (confirm dialog, status) and hook `useOpenPechaUpload` to assemble payload from editor content.
>   - **Utils**: Introduce `calculateAnnotations` to compute segmentation/annotation spans.
>   - **Types**: Extend `Document` to include `language` and `metadata` (`instance_id`, `text_id`, `docId`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecdddcd10399940b8280f8a8a0c651158249eb55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->