### PR TITLE
fix : Restore 'Replace to Proper Line' Feature for OpenPecha Texts

### DIFF
--- a/frontend/src/components/ChatSidebar/components/ChatInput.tsx
+++ b/frontend/src/components/ChatSidebar/components/ChatInput.tsx
@@ -2,7 +2,6 @@ import { Brain, Send, X } from "lucide-react";
 import {
   type KeyboardEvent,
   useCallback,
-  useEffect,
   useState,
 } from "react";
 import { useTranslation as useTranslationI18next } from "react-i18next";
@@ -31,20 +30,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
 }) => {
   const { t } = useTranslationI18next();
   const [input, setInput] = useState("");
-  const [shouldStartTranslation, setShouldStartTranslation] = useState(false);
   const {
     isTranslating,
-    setManualText,
-    setInputMode,
     startTranslation,
-    manualText,
-    inputMode,
     config,
     handleConfigChange,
     selectedAgentId,
     selectedText,
     clearSelection,
-    setInstruction,
   } = useTranslation();
 
   const {
@@ -52,37 +45,13 @@ const ChatInput: React.FC<ChatInputProps> = ({
     isLoading: isLoadingModels,
   } = useModels();
 
-  // Effect to start translation when manual text is set from ChatInput
-  useEffect(() => {
-    if (
-      shouldStartTranslation &&
-      inputMode === "manual" &&
-      manualText.trim() &&
-      !isTranslating
-    ) {
-      setShouldStartTranslation(false);
-      startTranslation();
-    }
-  }, [
-    shouldStartTranslation,
-    inputMode,
-    manualText,
-    isTranslating,
-    startTranslation,
-  ]);
   const handleSend = useCallback(() => {
     if (disabled || isTranslating || !selectedAgentId || !selectedText?.trim()) return;
 
     const instructionText = input.trim();
-    if (instructionText) {
-      setInstruction(instructionText);
-    }
-
-    setInputMode("manual");
-    setManualText(selectedText);
-    setShouldStartTranslation(true);
+    startTranslation(instructionText || undefined);
     setInput("");
-  }, [input, disabled, isTranslating, selectedAgentId, selectedText, setInputMode, setManualText, setInstruction, startTranslation]);
+  }, [input, disabled, isTranslating, selectedAgentId, selectedText, startTranslation]);
 
   const handleKeyPress = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/ChatSidebar/components/ResultsPanel.tsx
+++ b/frontend/src/components/ChatSidebar/components/ResultsPanel.tsx
@@ -24,14 +24,12 @@ import { useTranslation as useTranslationI18next } from "react-i18next";
 
 interface ResultsPanelProps {
   className?: string;
-  inputMode: "selection" | "manual";
 }
 
 type PanelType = "translation" | "glossary" | "inconsistency" | "standardized";
 
 const ResultsPanel: React.FC<ResultsPanelProps> = ({
   className = "",
-  inputMode,
 }) => {
   const { t } = useTranslationI18next();
   const [expandedPanel, setExpandedPanel] = useState<PanelType | null>(null);
@@ -151,9 +149,7 @@ const ResultsPanel: React.FC<ResultsPanelProps> = ({
             </Button>
 
             <div className="flex items-center gap-2">
-              {hasTranslationResults &&
-                !isTranslating &&
-                inputMode === "selection" && (
+              {hasTranslationResults && !isTranslating && (
                   <Tooltip delayDuration={5}>
                     <TooltipTrigger>
                       <Button

--- a/frontend/src/components/ChatSidebar/components/sidebar/ActionButtonGrid.tsx
+++ b/frontend/src/components/ChatSidebar/components/sidebar/ActionButtonGrid.tsx
@@ -13,14 +13,12 @@ import { useTranslation } from "../../contexts/TranslationContext";
 
 interface ActionButtonGridProps {
   hasInputText: boolean;
-  inputMode?: "selection" | "manual";
   onTranslate: () => void;
   onGlossaryExtract: () => void;
 }
 
 const ActionButtonGrid: React.FC<ActionButtonGridProps> = ({
   hasInputText,
-  inputMode = "selection",
   onTranslate,
   onGlossaryExtract,
 }) => {
@@ -71,11 +69,6 @@ const ActionButtonGrid: React.FC<ActionButtonGridProps> = ({
             <Languages className="w-5 h-5" />
             <span className="text-xs font-medium">
               {t("translation.translate")}
-              {inputMode === "manual" && (
-                <span className="block text-[10px] opacity-75">
-                  Manual Input
-                </span>
-              )}
             </span>
           </>
         )}

--- a/frontend/src/components/ChatSidebar/hooks/useTranslationController.ts
+++ b/frontend/src/components/ChatSidebar/hooks/useTranslationController.ts
@@ -24,13 +24,7 @@ export const useTranslationController = ({
   const [analysisSourceItems, setAnalysisSourceItems] = useState<
     GlossaryItem[]
   >([]);
-  // Manual input state with character limit
-  const CHARACTER_LIMIT = 5000; // Set character limit for manual input
-  const [manualText, setManualText] = useState<string>("");
   const [instruction, setInstruction] = useState<string>("");
-  const [inputMode, setInputMode] = useState<"selection" | "manual">(
-    "selection"
-  );
 
   // Get translation settings
   const { config, updateConfig, isSidebarCollapsed, setIsSidebarCollapsed } =
@@ -87,20 +81,9 @@ export const useTranslationController = ({
     scrollToLineNumber,
   });
 
-  // Handle manual text input with character limit
-  const handleManualTextChange = useCallback(
-    (text: string) => {
-      if (text.length <= CHARACTER_LIMIT) {
-        setManualText(text);
-      }
-    },
-    [CHARACTER_LIMIT]
-  );
-
-  // Get current line numbers (only for selection mode)
   const getCurrentLineNumbers = useCallback(() => {
-    return inputMode === "selection" ? selectedTextLineNumbers : null;
-  }, [inputMode, selectedTextLineNumbers]);
+    return selectedTextLineNumbers;
+  }, [selectedTextLineNumbers]);
   // Translation operations hook
   const {
     isTranslating,
@@ -118,10 +101,7 @@ export const useTranslationController = ({
     selectedTextLineNumbers: getCurrentLineNumbers(),
     selectedAgentId,
     onStreamComplete: (finalResults) => {
-      // Clear UI selection but keep line numbers for replace functionality
-      if (inputMode === "selection") {
-        clearUISelection();
-      }
+      clearUISelection();
 
       const items = finalResults.map((r) => ({
         original_text: r.originalText,
@@ -212,14 +192,8 @@ export const useTranslationController = ({
   ) => {
     updateConfig(key, value);
   };
-  function getTextToTranslate() {
-    if (selectedText.trim() !== "") {
-      return selectedText;
-    }
-    return manualText.trim();
-  }
-  const startTranslation = async () => {
-    const currentText = getTextToTranslate();
+  const startTranslation = async (directInstruction?: string) => {
+    const currentText = selectedText.trim();
 
     if (!currentText) {
       setError("Please select text or enter text to translate");
@@ -228,18 +202,16 @@ export const useTranslationController = ({
 
     let segment: { start: number; end: number } | undefined;
 
-    if (selectedText.trim() !== "") {
-      const editorId = activeSelectedEditor ?? activeEditor;
-      const storedSelection = editorId ? selections[editorId] : null;
-      if (storedSelection?.range) {
-        segment = {
-          start: storedSelection.range.index,
-          end: storedSelection.range.index + storedSelection.range.length - 1,
-        };
-      }
+    const editorId = activeSelectedEditor ?? activeEditor;
+    const storedSelection = editorId ? selections[editorId] : null;
+    if (storedSelection?.range) {
+      segment = {
+        start: storedSelection.range.index,
+        end: storedSelection.range.index + storedSelection.range.length - 1,
+      };
     }
 
-    const currentInstruction = instruction.trim() || undefined;
+    const currentInstruction = directInstruction?.trim() || instruction.trim() || undefined;
 
     resetCopyFeedback();
     resetGlossaryInternal();
@@ -319,17 +291,12 @@ export const useTranslationController = ({
     setIsSidebarCollapsed,
     selectedAgentId,
 
-    // Text input (selection + manual)
+    // Text input (selection)
     selectedText,
     setSelectedText,
     activeSelectedEditor,
     selectedTextLineNumbers,
-    manualText,
-    inputMode,
-    CHARACTER_LIMIT,
     getCurrentLineNumbers,
-    setManualText: handleManualTextChange,
-    setInputMode,
     instruction,
     setInstruction,
     clearSelection,

--- a/frontend/src/components/ChatSidebar/index.tsx
+++ b/frontend/src/components/ChatSidebar/index.tsx
@@ -50,7 +50,6 @@ const ChatSidebarContent: React.FC<{
     translationResults,
     glossaryTerms,
     inconsistentTerms,
-    inputMode,
   } = useTranslation();
   useEffect(() => {
     if (selectedAgentDetail) {
@@ -176,7 +175,7 @@ const ChatSidebarContent: React.FC<{
       </div>
       <div className="flex-1 flex flex-col min-h-0">
         {showPanel ? (
-          <ResultsPanel inputMode={inputMode} />
+          <ResultsPanel />
         ) : (
 
           <ChatHistory


### PR DESCRIPTION
fixes https://github.com/OpenPecha/buddhistAI-translation/issues/258
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/0bdc0d92-4db4-4553-87d9-7b2246539a48" />
problem with mode . now we dont have manual mode but this was triggering some issue when we try to use select text + the instruction. 